### PR TITLE
Properly clean up after errors encountered during an analyze hook

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -20,24 +20,30 @@ module.exports = co.wrap(function* (entries, builder) {
       let file = tree.addFile(path, !!entry);
       if (file.analyzing) return;
 
-      file.analyzing = true;
-      // preread is always run, as it has the opportunity to mark a file as
-      // "dirty" so it will be analyzed. (such as when an mtime changes)
-      // preread also always uses the original file type in case later plugins
-      // change the type, allowing entries to be transpiled and still picked up
-      // correctly.
-      yield hooks.run('preread', file.initialType(), file, tree, builder);
-      if (!file.analyzed) {
-        debug('analyzing %s', file.path);
-        yield hooks.run('read', file.type, file, tree, builder);
-        yield hooks.run('postread', file.type, file, tree, builder);
-        yield hooks.run('predependencies', file.type, file, tree, builder);
-        yield hooks.run('dependencies', file.type, file, tree, builder);
-        // the postdependencies hook runs at the outset of the build phase
-        file.analyzed = true;
-        debug('analyzed %s', file.path);
+      try {
+        file.analyzing = true;
+        // preread is always run, as it has the opportunity to mark a file as
+        // "dirty" so it will be analyzed. (such as when an mtime changes)
+        // preread also always uses the original file type in case later plugins
+        // change the type, allowing entries to be transpiled and still picked
+        // up correctly.
+        yield hooks.run('preread', file.initialType(), file, tree, builder);
+        if (!file.analyzed) {
+          debug('analyzing %s', file.path);
+          yield hooks.run('read', file.type, file, tree, builder);
+          yield hooks.run('postread', file.type, file, tree, builder);
+          yield hooks.run('predependencies', file.type, file, tree, builder);
+          yield hooks.run('dependencies', file.type, file, tree, builder);
+          // the postdependencies hook runs at the outset of the build phase
+          file.analyzed = true;
+          debug('analyzed %s', file.path);
+        }
+        file.analyzing = false;
+      } catch (err) {
+        file.analyzing = false;
+        file.dirty();
+        throw err;
       }
-      file.analyzing = false;
 
       let deps = tree.dependenciesOf(file.path).filter(function (path) {
         let file = tree.getFile(path);

--- a/test/builder.js
+++ b/test/builder.js
@@ -180,6 +180,20 @@ describe('Builder()', function () {
 
         return mako.analyze(fixture('text/a.txt'));
       });
+
+      it('should not leave the analyzing flag on when an error is thrown (#7)', function () {
+        let mako = new Builder();
+        let entry = fixture('text/a.txt');
+        let tree = mako.tree;
+
+        mako[hook]('txt', function () {
+          throw new Error('fail');
+        });
+
+        return mako.analyze(entry).catch(function () {
+          assert.isFalse(tree.getFile(entry).analyzing);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This fixes #7 by resetting the `analyzing` flag and calling `file.dirty()` so subsequent builds will retry this file. (currently, I believe it will just end up in some sort of limbo, since the `analyzing` flag remains on)