### PR TITLE
Logging support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-let Builder = require('./lib/builder');
+let Builder = require('./lib/mako');
 
 module.exports = function () {
   return new Builder();

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -8,15 +8,16 @@ let relative = require('./utils').relative;
 
 module.exports = co.wrap(function* (entries, builder) {
   debug('analyze %d files', entries.length);
+
   let hooks = builder.hooks;
   let tree = builder.tree;
   let analyzed = new Set(); // keeps track of files analyzed during this cycle
 
-  yield entries.map(entry => analyze(entry, true));
+  yield entries.map(entry => co(analyze(entry, true)));
 
   // if any files deep in the hierarchy were marked dirty after the previous
   // build, they would not be reached by this recursive processing, so we find
-  // those in the list and analyze them directly (recursion will pick up there)
+  // those in the list and analyze them directly (recursively)
   yield tree.getFiles({ objects: true })
     .filter(file => !file.analyzed)
     .map(file => analyze(file.path));
@@ -28,41 +29,44 @@ module.exports = co.wrap(function* (entries, builder) {
    *
    * @param {String} path      The absolute path to the file.
    * @param {Boolean} [entry]  Whether this file is an entry.
-   * @return {Promise}
    */
-  function analyze(path, entry) {
-    return co(function* () {
-      debug('start %s', relative(path));
-      let file = tree.addFile(path, !!entry);
-      if (file.analyzing || analyzed.has(path)) return;
+  function* analyze(path, entry) {
+    debug('start %s', relative(path));
+    let file = tree.addFile(path, !!entry);
+    if (file.analyzing || analyzed.has(path)) return;
+    builder.emit('analyze', file);
 
-      try {
-        file.analyzing = true;
-        // preread is always run, as it has the opportunity to mark a file as
-        // "dirty" so it will be analyzed. (such as when an mtime changes)
-        // preread also always uses the original file type in case later plugins
-        // change the type, allowing entries to be transpiled and still picked
-        // up correctly.
-        yield hooks.run('preread', file.initialType(), file, tree, builder);
-        if (!file.analyzed) {
-          debug('analyzing %s', relative(file.path));
-          yield hooks.run('read', file.type, file, tree, builder);
-          yield hooks.run('postread', file.type, file, tree, builder);
-          yield hooks.run('predependencies', file.type, file, tree, builder);
-          yield hooks.run('dependencies', file.type, file, tree, builder);
-          // the postdependencies hook runs at the outset of the build phase
-          file.analyzed = true;
-          analyzed.add(file.path);
-          debug('analyzed %s', relative(path));
-        }
-        file.analyzing = false;
-      } catch (err) {
-        file.analyzing = false;
-        file.dirty();
-        throw err;
+    try {
+      file.analyzing = true;
+      // preread is always run, as it has the opportunity to mark a file as
+      // "dirty" so it will be analyzed. (such as when an mtime changes)
+      // preread also always uses the original file type in case later
+      // plugins change the type, allowing entries to be transpiled and
+      // still picked up correctly.
+      yield hooks.run('preread', file.initialType(), file, tree, builder);
+      if (!file.analyzed) {
+        debug('analyzing %s', relative(file.path));
+
+        yield hooks.run('read', file.type, file, tree, builder);
+        yield hooks.run('postread', file.type, file, tree, builder);
+        yield hooks.run('predependencies', file.type, file, tree, builder);
+        yield hooks.run('dependencies', file.type, file, tree, builder);
+        // the postdependencies hook runs at the outset of the build phase
+
+        file.analyzed = true;
+        analyzed.add(file.path);
+        debug('analyzed %s', relative(path));
       }
+      file.analyzing = false;
+    } catch (err) {
+      file.analyzing = false;
+      file.dirty();
+      throw err;
+    }
 
-      yield file.dependencies().map(dep => analyze(dep));
-    });
+    yield file.dependencies().map(dep => analyze(dep));
+
+    if (entry) debug('analyzed dependencies for %s', relative(path));
+    builder.emit('analyzed', file);
   }
 });

--- a/lib/build.js
+++ b/lib/build.js
@@ -17,24 +17,19 @@ module.exports = co.wrap(function* (entries, tree, builder) {
   // during prewrite, files must be processed sequentially to allow unrolling
   // the dependencies cleanly
   for (let file of tree.getFiles(params)) {
+    if (file.entry) builder.emit('build', file);
     yield hooks.run('postdependencies', file.type, file, tree, builder);
   }
 
-  yield tree.getFiles(params).map(run('prewrite'));
-  yield tree.getFiles(params).map(run('write'));
-  yield tree.getFiles(params).map(run('postwrite'));
+  // fetch the list of files again because it can change during the
+  // postdependencies hook (but won't be modified during write as of now)
+  for (let file of tree.getFiles(params)) {
+    builder.emit('write', file);
+    yield hooks.run('prewrite', file.type, file, tree, builder);
+    yield hooks.run('write', file.type, file, tree, builder);
+    yield hooks.run('postwrite', file.type, file, tree, builder);
+    builder.emit('written', file);
+  }
 
   return tree;
-
-  /**
-   * Helper function for running build hooks.
-   *
-   * @param {String} name  The hook to run.
-   * @return {GeneratorFunction}
-   */
-  function run(name) {
-    return function* (file) {
-      yield hooks.run(name, file.type, file, tree, builder);
-    };
-  }
 });

--- a/lib/mako.js
+++ b/lib/mako.js
@@ -4,6 +4,7 @@
 let analyze = require('./analyze');
 let build = require('./build');
 let debug = require('debug')('mako:builder');
+let Emitter = require('events');
 let flatten = require('array-flatten');
 let Hooks = require('./hooks');
 let Tree = require('mako-tree');
@@ -15,12 +16,13 @@ let Tree = require('mako-tree');
  *
  * @class
  */
-class Builder {
+class Builder extends Emitter {
   /**
    * Builds a new instance.
    */
   constructor() {
     debug('initialize');
+    super();
     this.hooks = new Hooks();
     this.tree = new Tree();
   }

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 let assert = require('chai').assert;
-let Builder = require('../lib/builder');
+let Builder = require('../lib/mako');
 let mako = require('..');
 
 describe('mako', function () {


### PR DESCRIPTION
This turns the `Builder` instance into an `EventEmitter` and am starting to emit events throughout the build process. The intended use-case is logging, but I'm sure other cases will come up in the future.