### PR TITLE
only emit analyze event when file is dirty

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -34,7 +34,6 @@ module.exports = co.wrap(function* (entries, builder) {
     debug('start %s', relative(path));
     let file = tree.addFile(path, !!entry);
     if (file.analyzing || analyzed.has(path)) return;
-    builder.emit('analyze', file);
 
     try {
       file.analyzing = true;
@@ -46,6 +45,8 @@ module.exports = co.wrap(function* (entries, builder) {
       yield hooks.run('preread', file.initialType(), file, tree, builder);
       if (!file.analyzed) {
         debug('analyzing %s', relative(file.path));
+        builder.emit('analyze', file);
+
 
         yield hooks.run('read', file.type, file, tree, builder);
         yield hooks.run('postread', file.type, file, tree, builder);
@@ -53,9 +54,10 @@ module.exports = co.wrap(function* (entries, builder) {
         yield hooks.run('dependencies', file.type, file, tree, builder);
         // the postdependencies hook runs at the outset of the build phase
 
-        file.analyzed = true;
-        analyzed.add(file.path);
         debug('analyzed %s', relative(path));
+        builder.emit('analyzed', file);
+        analyzed.add(file.path);
+        file.analyzed = true;
       }
       file.analyzing = false;
     } catch (err) {
@@ -67,6 +69,5 @@ module.exports = co.wrap(function* (entries, builder) {
     yield file.dependencies().map(dep => analyze(dep));
 
     if (entry) debug('analyzed dependencies for %s', relative(path));
-    builder.emit('analyzed', file);
   }
 });


### PR DESCRIPTION
This PR changes the place where the analyze event is emitted, before it would pretty much fire off for all files, whenever there was a change in one file. For example, if I change `index.coffee`:

```
analyzing /Users/matt/Projects/scooby/example/basic/index.jade
analyzing /Users/matt/Projects/scooby/example/basic/index.css
analyzing /Users/matt/Projects/scooby/example/basic/lucy.gif
analyzing /Users/matt/Projects/scooby/example/basic/index.js
analyzed /Users/matt/Projects/scooby/example/basic/lucy.gif
analyzing /Users/matt/Projects/scooby/example/basic/test.css
analyzing /Users/matt/Projects/scooby/node_modules/normalize.css/normalize.css
analyzing /Users/matt/Projects/scooby/node_modules/mako-js/node_modules/process/browser.js
analyzing /Users/matt/Projects/scooby/example/basic/es6.jsx
analyzing /Users/matt/Projects/scooby/example/basic/index.coffee
analyzing /Users/matt/Projects/scooby/example/basic/test.js
analyzing /Users/matt/Projects/scooby/node_modules/superagent/lib/client.js
analyzing /Users/matt/Projects/scooby/example/basic/lucy.gif
analyzed /Users/matt/Projects/scooby/example/basic/lucy.gif
analyzed /Users/matt/Projects/scooby/example/basic/test.css
analyzed /Users/matt/Projects/scooby/node_modules/normalize.css/normalize.css
analyzed /Users/matt/Projects/scooby/example/basic/index.css
analyzed /Users/matt/Projects/scooby/node_modules/mako-js/node_modules/process/browser.js
analyzed /Users/matt/Projects/scooby/example/basic/es6.jsx
analyzed /Users/matt/Projects/scooby/example/basic/test.js
analyzing /Users/matt/Projects/scooby/node_modules/superagent/node_modules/reduce-component/index.js
analyzing /Users/matt/Projects/scooby/node_modules/superagent/node_modules/component-emitter/index.js
analyzed /Users/matt/Projects/scooby/node_modules/superagent/node_modules/reduce-component/index.js
analyzed /Users/matt/Projects/scooby/node_modules/superagent/node_modules/component-emitter/index.js
analyzed /Users/matt/Projects/scooby/node_modules/superagent/lib/client.js
analyzed /Users/matt/Projects/scooby/example/basic/index.coffee
analyzed /Users/matt/Projects/scooby/example/basic/index.js
analyzed /Users/matt/Projects/scooby/example/basic/index.jade
built /Users/matt/Projects/scooby/example/basic/index.jade
writing /Users/matt/Projects/scooby/example/basic/lucy.gif
wrote /Users/matt/Projects/scooby/example/basic/lucy.gif
writing /Users/matt/Projects/scooby/example/basic/index.js
wrote /Users/matt/Projects/scooby/example/basic/index.js
writing /Users/matt/Projects/scooby/example/basic/index.jade
wrote /Users/matt/Projects/scooby/example/basic/index.jade
writing /Users/matt/Projects/scooby/example/basic/index.css
wrote /Users/matt/Projects/scooby/example/basic/index.css
```

After this PR:

```
analyzing /Users/matt/Projects/scooby/example/basic/index.coffee
analyzed /Users/matt/Projects/scooby/example/basic/index.coffee
built /Users/matt/Projects/scooby/example/basic/index.jade
writing /Users/matt/Projects/scooby/example/basic/lucy.gif
wrote /Users/matt/Projects/scooby/example/basic/lucy.gif
writing /Users/matt/Projects/scooby/example/basic/index.js
wrote /Users/matt/Projects/scooby/example/basic/index.js
writing /Users/matt/Projects/scooby/example/basic/index.jade
wrote /Users/matt/Projects/scooby/example/basic/index.jade
writing /Users/matt/Projects/scooby/example/basic/index.css
wrote /Users/matt/Projects/scooby/example/basic/index.css
```