### PR TITLE
using a queue during analyze instead of stair-stepping

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -3,10 +3,11 @@
 
 let co = require('co');
 let debug = require('debug')('mako:analyze');
+let Queue = require('./queue');
 let relative = require('./utils').relative;
 
 
-module.exports = co.wrap(function* (build) {
+module.exports = function (build) {
   debug('analyzing %j', build.entries.map(relative));
 
   let entries = build.entries;
@@ -15,16 +16,21 @@ module.exports = co.wrap(function* (build) {
   let tree = runner.tree;
   let analyzed = new Set(); // keeps track of files analyzed during this cycle
 
-  yield entries.map(entry => co(analyze(entry, true)));
+  let queue = new Queue({
+    // concurrency: 1,
+    factory: co.wrap(analyze)
+  });
+
+  entries.forEach(entry => queue.add(entry, true));
 
   // if any files deep in the hierarchy were marked dirty after the previous
   // build, they would not be reached by this recursive processing, so we find
   // those in the list and analyze them directly (recursively)
-  yield tree.getFiles({ objects: true })
-    .filter(file => !file.analyzed)
-    .map(file => analyze(file.path));
+  // tree.getFiles({ objects: true })
+  //   .filter(file => !file.analyzed)
+  //   .forEach(file => queue(file.path));
 
-  return build;
+  return queue.then(() => build, err => Promise.reject(err));
 
   /**
    * Helper for running analysis on a file.
@@ -70,7 +76,6 @@ module.exports = co.wrap(function* (build) {
       throw err;
     }
 
-    yield file.dependencies().map(dep => analyze(dep));
-    if (entry) debug('analyzed dependencies for %s', relative(path));
+    file.dependencies().forEach(dep => queue.add(dep));
   }
-});
+};

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,0 +1,60 @@
+
+'use strict';
+
+let debug = require('debug')('mako:queue');
+
+const defaults = {
+  concurrency: Infinity,
+  factory: null
+};
+
+class Queue {
+  constructor(options) {
+    debug('initialize %j', options);
+    this.config = Object.assign({}, defaults, options);
+    this.available = [];
+    this.pending = new Set();
+    this.done = new Set();
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+
+  add() {
+    let args = [].slice.call(arguments);
+    debug('add %j', args);
+    this.available.push(args);
+    this.run();
+  }
+
+  run() {
+    debug('running');
+    while (this.pending.size < this.config.concurrency) {
+      if (!this.available.length) break;
+      this.start(this.available.shift());
+    }
+  }
+
+  start(args) {
+    debug('start %j', args);
+    let p = this.config.factory.apply(null, args);
+    this.pending.add(p);
+    p.then(() => this.finish(p, args), err => this.reject(err));
+  }
+
+  finish(p, args) {
+    debug('finish %j', args);
+    this.pending.delete(p);
+    this.done.add(p);
+    this.run();
+    if (!this.available.length && !this.pending.size) this.resolve();
+  }
+
+  then() {
+    return this.promise.then.apply(this.promise, arguments);
+  }
+}
+
+
+module.exports = Queue;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -28,8 +28,13 @@ class Runner extends Emitter {
     debug('initialize');
     super();
     this.hooks = new Hooks();
-    this.tree = tree || new Tree();
-    if (tree) debug('using predefined tree');
+
+    if (tree) {
+      debug('using predefined tree');
+      this.tree = tree;
+    } else {
+      this.tree = new Tree();
+    }
   }
 
   /**


### PR DESCRIPTION
This addresses #14 by using a queue internally, rather than the current implementation which "stair-steps" each layer of the dependency tree. While I did see a 5-10% performance boost for a small project, I'm hoping this improvement will become more pronounced for larger projects. Currently, I'm not limiting the amount of concurrency, but I'm thinking of adding a default limit in a future change.

/cc @matthewmueller I'm going to release this as a patch update to mako core, so let me know right away if you see any bad behavior. **UPDATE:** nvm, I'm gonna bump minor with all my changes this weekend.