### PR TITLE
Assemble: Adding more parallelization, allowing prewrite to modify tree

### DIFF
--- a/lib/assemble.js
+++ b/lib/assemble.js
@@ -26,15 +26,18 @@ module.exports = co.wrap(function* (build) {
     yield hooks.run('postdependencies', file.type, file, tree, build);
   }
 
-  // fetch the list of files again because it can change during the
-  // postdependencies hook (but won't be modified during write as of now)
-  for (let file of tree.getFiles(params)) {
+  // fetch the list of files again because it can change during postdependencies
+  yield tree.getFiles(params).map(file => {
     runner.emit('before:assemble', file);
-    yield hooks.run('prewrite', file.type, file, tree, build);
+    return hooks.run('prewrite', file.type, file, tree, build);
+  });
+
+  // fetch the list of files again because it can change during prewrite
+  yield tree.getFiles(params).map(function* (file) {
     yield hooks.run('write', file.type, file, tree, build);
     yield hooks.run('postwrite', file.type, file, tree, build);
     runner.emit('after:assemble', file);
-  }
+  });
 
   timer();
   return build;


### PR DESCRIPTION
This makes some improvements to the assemble phase. (particularly the write hooks)

 1. The `prewrite` hook can now modify the build tree, allowing things like minifiers to other files for their output
 2. Changing the parallelization for the write hooks overall:
    - The `prewrite` hooks are all run in parallel as a group
    - Afterwards, all files are run in parallel as a group for `write` then `postwrite` (these 2 hooks are not split apart as of now)

This is a precursor to a new sourcemaps plugin I'm working on, but it should also improve the experience for other similar plugins.